### PR TITLE
Fix card closing animation issue

### DIFF
--- a/Cards/Sources/Animator.swift
+++ b/Cards/Sources/Animator.swift
@@ -55,14 +55,15 @@ class Animator: NSObject, UIViewControllerAnimatedTransitioning {
             })
             
             // Layout with bounce effect
+            let originalFrame = card.originalFrame
             UIView.animate(withDuration: velocity/2, delay: 0, options: .curveEaseOut, animations: {
                 
-                detailVC.layout(self.card.originalFrame, isPresenting: false, transform: bounce)
+                detailVC.layout(originalFrame, isPresenting: false, transform: bounce)
                 self.card.delegate?.cardIsHidingDetail?(card: self.card)
                 
             }) { _ in UIView.animate(withDuration: self.velocity/2, delay: 0, options: .curveEaseOut, animations: {
                     
-                detailVC.layout(self.card.originalFrame, isPresenting: false)
+                detailVC.layout(originalFrame, isPresenting: false)
                 self.card.delegate?.cardIsHidingDetail?(card: self.card)
                 })
             }


### PR DESCRIPTION
This pull request fixes the issue #56.  
At the time when the animation in the completion block of the first animation executes the `self.card.originalFrame` changes because of  `detailVC.layout(originalFrame, isPresenting: false, transform: bounce)` in the first part of the animation. That is why we have to preserve the `originalFrame` before executing the animations and use that value when animating.